### PR TITLE
Fix Sticker Mule link

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1142,7 +1142,7 @@ THEBRIO TODO
                class="sponsor-image elast"></a>
         </div>
          <div class="sponsors_main2 com-partner">
-            <a href="stickermule.com" target="_blank"><img src="./images/sponsors/stickermule.png"
+            <a href="https://stickermule.com" target="_blank"><img src="./images/sponsors/stickermule.png"
                class="sponsor-image elast"></a>
         </div>
          <div class="sponsors_main2 com-partner">


### PR DESCRIPTION
Hello! 👋 This PR fixes the Sticker Mule link the sponsors section.

The screenshot below shows the link it goes to currently.
<img width="910" alt="Screen Shot 2022-03-28 at 19 43 15" src="https://user-images.githubusercontent.com/72365100/160522377-eff8a59e-34e0-467e-a9d7-9df3f76ef7bf.png">
